### PR TITLE
Improve stall/grant logic

### DIFF
--- a/rtl/trace_debugger.sv
+++ b/rtl/trace_debugger.sv
@@ -489,6 +489,7 @@ module trace_debugger import trdb_pkg::*;
          .flush_stream_i(flush_stream),
          .flush_confirm_o(flush_confirm),
          .data_o(packet_word),
+         .grant_i(~stall_i),
          .valid_o(packet_word_valid));
 
     assign packet_word_o = packet_word;

--- a/tb/driver.svh
+++ b/tb/driver.svh
@@ -240,6 +240,8 @@ class Driver;
         // send to scoreboard
         mail.put(stimuli);
 
+        this.duv_if.stall = 1'b1;
+
         //TODO: fix this hack
         apply_zero();
 
@@ -256,6 +258,10 @@ class Driver;
         for(int i = stimuli.ivalid.size() - 1; i >= 0; i--) begin
 
             @(posedge this.duv_if.clk_i);
+
+            // tb starts accepting transactions
+            this.duv_if.stall = ~this.duv_if.packet_word_valid;
+
             #STIM_APPLICATION_DEL;
 
             // apply stimuli pop_back()


### PR DESCRIPTION
This allows us to pass the grant signal from outside (accepting the
generated packets) through the alignment statemachine to the internal
packet fifo, otherwise we would have to put a fifo between the alignment
unit and the output interface too.