### PR TITLE
Add various testbench improvments

### DIFF
--- a/include/trdb_tb_pkg.sv
+++ b/include/trdb_tb_pkg.sv
@@ -67,7 +67,7 @@ package trdb_tb_pkg;
 `include "../tb/stimuli.svh"
 `include "../tb/response.svh"
 `include "../tb/driver.svh"
-`include "../tb/monitor.svh"
+`include "../tb/reader.svh"
 `include "../tb/scoreboard.svh"
 
 endpackage // trdb_tb_pkg

--- a/rtl/trace_debugger.sv
+++ b/rtl/trace_debugger.sv
@@ -33,7 +33,7 @@ module trace_debugger import trdb_pkg::*;
      // generated packets, which go the the udma (or somewhere else)
      output logic [XLEN-1:0]    packet_word_o,
      output logic               packet_word_valid_o,
-     input logic                stall_i);
+     input logic                grant_i);
 
 
     // general control of this module
@@ -489,7 +489,7 @@ module trace_debugger import trdb_pkg::*;
          .flush_stream_i(flush_stream),
          .flush_confirm_o(flush_confirm),
          .data_o(packet_word),
-         .grant_i(~stall_i),
+         .grant_i(grant_i),
          .valid_o(packet_word_valid));
 
     assign packet_word_o = packet_word;
@@ -609,7 +609,7 @@ module trace_debugger import trdb_pkg::*;
          .trace_priv_match_i(trace_priv_match),
          .trace_range_match_i(trace_range_match),
          .trace_fifo_overflow_i(fifo_overflow),
-         .external_fifo_overflow_i(stall_i), //external stall is a fifo overflow
+         .external_fifo_overflow_i(~grant_i), //external stall is a fifo overflow
          .sw_word_o(sw_word),
          .sw_valid_o(sw_valid),
          .sw_grant_i(sw_grant),

--- a/tb/driver.svh
+++ b/tb/driver.svh
@@ -240,8 +240,6 @@ class Driver;
         // send to scoreboard
         mail.put(stimuli);
 
-        this.duv_if.stall = 1'b1;
-
         //TODO: fix this hack
         apply_zero();
 
@@ -259,8 +257,8 @@ class Driver;
 
             @(posedge this.duv_if.clk_i);
 
-            // tb starts accepting transactions
-            this.duv_if.stall = ~this.duv_if.packet_word_valid;
+            // // tb starts accepting transactions
+            // this.duv_if.stall = ~this.duv_if.packet_word_valid;
 
             #STIM_APPLICATION_DEL;
 
@@ -299,9 +297,9 @@ class Driver;
         #STIM_APPLICATION_DEL;
         apply_zero();
 
-        @(posedge this.duv_if.clk_i);
-        #STIM_APPLICATION_DEL;
-        apply_zero();
+        repeat (10) begin
+            @(posedge this.duv_if.clk_i);
+        end
 
         tb_eos = 1'b1;
 

--- a/tb/monitor.svh
+++ b/tb/monitor.svh
@@ -46,7 +46,7 @@ class Monitor;
                 break;
             end
 
-            if(this.duv_if.packet_word_valid == 1'b1) begin
+            if(this.duv_if.packet_word_valid && this.duv_if.grant) begin
                 if(off == 0) begin
                     //we are dealing with a new packet
                     packet.bits = '0;
@@ -118,7 +118,7 @@ class Monitor;
                 break;
             end
 
-            if(this.duv_if.packet_word_valid == 1'b1) begin
+            if(this.duv_if.packet_word_valid && this.duv_if.grant) begin
                 packet_word = this.duv_if.packet_word;
                 if($test$plusargs("debug"))
                     $display("[Monitor]@%t: slurping %h", $time, packet_word);

--- a/tb/monitor.svh
+++ b/tb/monitor.svh
@@ -37,22 +37,20 @@ class Monitor;
         Response response;
 
         forever begin: acquire
-            @(posedge this.duv_if.clk_i);
-            #STIM_APPLICATION_DEL;
+            @(this.duv_if.cb);
 
-            #(RESP_ACQUISITION_DEL - STIM_APPLICATION_DEL);
             if(tb_eos == 1'b1) begin
                 $display("[MONITOR]@%t: Signaled end of simulation.", $time);
                 break;
             end
 
-            if(this.duv_if.packet_word_valid && this.duv_if.grant) begin
+            if(this.duv_if.cb.packet_word_valid && this.duv_if.cb.grant) begin
                 if(off == 0) begin
                     //we are dealing with a new packet
                     packet.bits = '0;
                     pbits = (wordmod == 0 ?
-                             this.duv_if.packet_word[$clog2(PACKET_LEN)-1+7:7]:
-                             this.duv_if.packet_word[$clog2(PACKET_LEN)-1:0]);
+                             this.duv_if.cb.packet_word[$clog2(PACKET_LEN)-1+7:7]:
+                             this.duv_if.cb.packet_word[$clog2(PACKET_LEN)-1:0]);
 
                     // every other words (wordmod == 0) has an additional 7 bits
                     totalbits = pbits + (pbits/(32+32-7)) * 7
@@ -62,20 +60,20 @@ class Monitor;
                     max_reads = (totalbits + 32 - 1) / 32;
 
                     if(wordmod == 0)  begin
-                        packet.bits[packet_ptr+:32-7] = this.duv_if.packet_word[31:7];
+                        packet.bits[packet_ptr+:32-7] = this.duv_if.cb.packet_word[31:7];
                         packet_ptr += 32-7;
                     end else begin
-                        packet.bits[packet_ptr+:32] = this.duv_if.packet_word;
+                        packet.bits[packet_ptr+:32] = this.duv_if.cb.packet_word;
                         packet_ptr += 32;
                     end
                     off++;
 
                 end else begin
                     if(wordmod == 0)  begin
-                        packet.bits[packet_ptr+:32-7] = this.duv_if.packet_word[31:7];
+                        packet.bits[packet_ptr+:32-7] = this.duv_if.cb.packet_word[31:7];
                         packet_ptr += 32-7;
                     end else begin
-                        packet.bits[packet_ptr+:32] = this.duv_if.packet_word;
+                        packet.bits[packet_ptr+:32] = this.duv_if.cb.packet_word;
                         packet_ptr += 32;
                     end
                     off++;
@@ -108,18 +106,16 @@ class Monitor;
         Response                   response;
 
         forever begin: acquire
-            @(posedge this.duv_if.clk_i);
-            #STIM_APPLICATION_DEL;
+            @(this.duv_if.cb);
 
-            #(RESP_ACQUISITION_DEL - STIM_APPLICATION_DEL);
             if(tb_eos == 1'b1) begin
                 $display("[MONITOR]@%t: Signaled end of simulation.", $time);
                 $finish;
                 break;
             end
 
-            if(this.duv_if.packet_word_valid && this.duv_if.grant) begin
-                packet_word = this.duv_if.packet_word;
+            if(this.duv_if.cb.packet_word_valid && this.duv_if.cb.grant) begin
+                packet_word = this.duv_if.cb.packet_word;
                 if($test$plusargs("debug"))
                     $display("[Monitor]@%t: slurping %h", $time, packet_word);
 
@@ -165,7 +161,7 @@ class Monitor;
         acquire_bytewise(tb_eos);
 
         repeat(10)
-            @(posedge this.duv_if.clk_i);
+            @(this.duv_if.cb);
 
     endtask
 

--- a/tb/reader.svh
+++ b/tb/reader.svh
@@ -12,7 +12,7 @@
 // Description: Acquisition of output
 
 
-class Monitor;
+class Reader;
 
     virtual trace_debugger_if duv_if;
     mailbox #(Response) outbox_duv;
@@ -25,7 +25,7 @@ class Monitor;
 
     // old function that assumes that packets are packed in two words frames and
     // are always zero extended to fit into whole words
-    task acquire_word2(ref logic tb_eos);
+    task acquire_word2();
         // helper variables to parse packet
         automatic int pbits;
         automatic int totalbits;
@@ -38,11 +38,6 @@ class Monitor;
 
         forever begin: acquire
             @(this.duv_if.cb);
-
-            if(tb_eos == 1'b1) begin
-                $display("[MONITOR]@%t: Signaled end of simulation.", $time);
-                break;
-            end
 
             if(this.duv_if.cb.packet_word_valid && this.duv_if.cb.grant) begin
                 if(off == 0) begin
@@ -95,7 +90,7 @@ class Monitor;
 
     endtask
 
-    task acquire_bytewise(ref logic tb_eos);
+    task acquire_bytewise();
         logic [BUS_DATA_WIDTH-1:0] packet_word;
         logic [7:0]                packet_byte;
         int                        packet_byte_len;
@@ -105,19 +100,15 @@ class Monitor;
         automatic trdb_packet      packet;
         Response                   response;
 
+        int                        tmp = 1;
+
         forever begin: acquire
             @(this.duv_if.cb);
-
-            if(tb_eos == 1'b1) begin
-                $display("[MONITOR]@%t: Signaled end of simulation.", $time);
-                $finish;
-                break;
-            end
 
             if(this.duv_if.cb.packet_word_valid && this.duv_if.cb.grant) begin
                 packet_word = this.duv_if.cb.packet_word;
                 if($test$plusargs("debug"))
-                    $display("[Monitor]@%t: slurping %h", $time, packet_word);
+                    $display("[READER]@%t: slurping %h", $time, packet_word);
 
                 for(int i = 0; i < BUS_DATA_WIDTH/8; i++) begin
                     packet_byte        = packet_word[i*8+:8];
@@ -156,13 +147,13 @@ class Monitor;
         end
     endtask
 
-    task run(ref logic tb_eos);
-        // acquire_word2(tb_eos);
-        acquire_bytewise(tb_eos);
+    task run();
+        // acquire_word2();
+        acquire_bytewise();
 
         repeat(10)
             @(this.duv_if.cb);
 
     endtask
 
-endclass // Monitor
+endclass // Reader

--- a/tb/trace_debugger_if.sv
+++ b/tb/trace_debugger_if.sv
@@ -11,13 +11,15 @@
 // Author: Robert Balas (balasr@student.ethz.ch)
 // Description: Interface of the trace debugger module
 
-interface trace_debugger_if
-    (input logic                clk_i,
-     input logic                rst_ni,
-     input logic                test_mode_i);
+`timescale 1ns/1ns
 
+interface trace_debugger_if (
+    input logic clk_i,
+    input logic rst_ni,
+    input logic test_mode_i
+);
     import trdb_pkg::*;
-
+    import trdb_tb_pkg::*;
 
     // inputs
     logic                ivalid;
@@ -38,5 +40,34 @@ interface trace_debugger_if
 
     APB_BUS #(.APB_ADDR_WIDTH(32)) apb_bus();
 
+    clocking cb @(posedge clk_i);
+        default input #(CLK_PERIOD - RESP_ACQUISITION_DEL) output #STIM_APPLICATION_DEL;
+
+        // trace debugger
+        output ivalid;
+        output iexception;
+        output interrupt;
+        output cause;
+        output tval;
+        output priv;
+        output iaddr;
+        output instr;
+        output compressed;
+        inout grant;
+
+        input packet_word;
+        input packet_word_valid;
+
+        // apb
+        output paddr = apb_bus.paddr;
+        output pwdata = apb_bus.pwdata;
+        output pwrite = apb_bus.pwrite;
+        output psel = apb_bus.psel;
+        output penable = apb_bus.penable;
+        input  prdata = apb_bus.prdata;
+        input  pready = apb_bus.pready;
+        input  pslverr = apb_bus.pslverr;
+
+    endclocking
 
 endinterface

--- a/tb/trace_debugger_if.sv
+++ b/tb/trace_debugger_if.sv
@@ -30,7 +30,7 @@ interface trace_debugger_if
     logic [ILEN-1:0]     instr;
     logic                compressed;
 
-    logic                stall;
+    logic                grant;
 
     // outputs
     logic [XLEN-1:0]     packet_word;

--- a/tb/trace_debugger_wrapper.sv
+++ b/tb/trace_debugger_wrapper.sv
@@ -30,6 +30,6 @@ module trace_debugger_wrapper
          .apb_slave(duv_if.apb_bus),
          .packet_word_o(duv_if.packet_word),
          .packet_word_valid_o(duv_if.packet_word_valid),
-         .stall_i(duv_if.stall));
+         .grant_i(duv_if.grant));
 
 endmodule // trace_debugger_wrapper

--- a/tb/trdb_tb_top.sv
+++ b/tb/trdb_tb_top.sv
@@ -35,9 +35,9 @@ module trdb_tb_top #(
     trace_debugger_wrapper i_trace_debugger_wrapper(.duv_if(duv_if));
 
     // randomized handshake
-    always_ff @(posedge clk) begin
+    always_ff @(duv_if.cb) begin
         //duv_if.grant = repeat (NumRegs) @(posedge clk) duv_if.packet_word_valid;
-        duv_if.grant = $urandom_range(0, 1);
+        duv_if.cb.grant <= $urandom_range(0, 1);
     end
 
     //instantiate testbench

--- a/tb/trdb_tb_top.sv
+++ b/tb/trdb_tb_top.sv
@@ -14,7 +14,10 @@
 // TODO: inspect this value
 `timescale 1ns/1ns
 
-module trdb_tb_top;
+module trdb_tb_top #(
+    parameter NumRegs = 3
+);
+
     import trdb_tb_pkg::*;
 
     // testbench signals to dut
@@ -23,12 +26,19 @@ module trdb_tb_top;
     logic      eos_s = 'b0; //end of simulation
     logic      test_mode;
 
+
     assign test_mode = '0;
 
     trace_debugger_if duv_if(clk, rst_n, test_mode);
 
     //instantiate duv
     trace_debugger_wrapper i_trace_debugger_wrapper(.duv_if(duv_if));
+
+    // randomized handshake
+    always_ff @(posedge clk) begin
+        //duv_if.grant = repeat (NumRegs) @(posedge clk) duv_if.packet_word_valid;
+        duv_if.grant = $urandom_range(0, 1);
+    end
 
     //instantiate testbench
     trdb_tb i_trdb_tb(.tb_if(duv_if));


### PR DESCRIPTION
Use event instead of logic ref to signal end of simulation
Use join_any and above event to properly handle end of simulation and
scoreboard result reporting.
Rename monitor to reader (was conveying wrong intent).
Warn when there are unprocessed packets in the golden model or dut
mailbox.